### PR TITLE
I2C: Prevent corruption in aux() due to NACK

### DIFF
--- a/pyBusPirateLite/I2C.py
+++ b/pyBusPirateLite/I2C.py
@@ -327,16 +327,19 @@ class I2C(BusPirate):
 
 
         """
-        self.write(0x09)
-        if cmd in [0x00, 0x01, 0x02, 0x03, 0x10, 0x20]:
-            self.write(cmd)
-        else:
+        if cmd not in (0x00, 0x01, 0x02, 0x03, 0x10, 0x20):
             raise ProtocolError('Illegal extended AUX command')
-        resp = self.response(20, True)
+        self.write(0x09)
+        if self.response(1, binary=True) != b'\x01':
+            raise ProtocolError('Error in extended AUX command')
+        self.write(cmd)
+        resp = self.response(20, binary=True)
 
-        if resp[0] != 1:
-            raise ProtocolError(f'Error in extended AUX command {resp}')
-        return resp[1:-1].decode('ASCII')
+        # firmware ~7.1 responds to the command with text followed by another
+        # 0x01 confirmation. this behaivor was not well documented on the wiki
+        if resp[-1] != 0x01:
+            raise ProtocolError('Error in extended AUX command')
+        return resp[:-1].decode('ASCII')
 
     def configure(self, power=False, pullup=False, aux=False, cs=False):
         """Configure peripherals w=power, x=pullups, y=AUX, z=CS


### PR DESCRIPTION
In I2C.aux() the command should be checked before writing anything, or
else the BusPirate will be left in an odd state. An ACK should be found
before writing the command. In community firmware ~7.1, a second ACK is
present, but not documented on the wiki.