### PR TITLE
Fix BusPirate.response() regression from API change

### DIFF
--- a/pyBusPirateLite/BitBang.py
+++ b/pyBusPirateLite/BitBang.py
@@ -56,7 +56,7 @@ class BitBang(BusPirate):
 
         self.write(0x40 | ~ self.pins_direction & 0x1f)  # map input->1, output->0  **TODO**
         self.timeout(self.minDelay * 10)
-        return ord(self.response(1, True)) & 0x1f
+        return ord(self.response(1, binary=True)) & 0x1f
 
     @outputs.setter
     def outputs(self, pinlist=0):
@@ -84,7 +84,7 @@ class BitBang(BusPirate):
         self.pins_direction = pinlist & 0x1f
         self.write(0x40 | ~ self.pins_direction & 0x1f)  # map input->1, output->0
         self.timeout(self.minDelay * 10)
-        self.response(1, True)
+        self.response(1, binary=True)
 
     @property
     def pins(self):
@@ -98,7 +98,7 @@ class BitBang(BusPirate):
         """
         self.write(0x80 | (self.pins_state & 0x7f))
         self.timeout(self.minDelay * 10)
-        self.pins_state = ord(self.response(1, True)) & 0x7f
+        self.pins_state = ord(self.response(1, binary=True)) & 0x7f
         return self.pins_state
 
     @pins.setter
@@ -122,7 +122,7 @@ class BitBang(BusPirate):
         self.pins_state = pinlist & 0x7f
         self.write(0x80 | self.pins_state)
         self.timeout(self.minDelay * 10)
-        self.pins_state = ord(self.response(1, True)) & 0x7f
+        self.pins_state = ord(self.response(1, binary=True)) & 0x7f
 
     @property
     def adc(self):
@@ -135,7 +135,7 @@ class BitBang(BusPirate):
         """
         self.write(0x14)
         self.timeout(self.minDelay)
-        ret = self.response(2, True)
+        ret = self.response(2, binary=True)
         voltage = (ret[0] << 8) + ret[1]
         voltage = (voltage * 6.6) / 1024
         return voltage
@@ -151,7 +151,7 @@ class BitBang(BusPirate):
         self.write(0x15)
 
     def get_next_adc_voltage(self):
-        ret = self.response(2, True)
+        ret = self.response(2, binary=True)
         voltage = (ret[0] << 8) + ret[1]
         voltage = (voltage * 6.6) / 1024
 
@@ -162,7 +162,7 @@ class BitBang(BusPirate):
             self.recurse_end()
             return voltage
 
-        self.response(1, True)        # get an additional byte and then flush
+        self.response(1, binary=True) # get an additional byte and then flush
         self.port.flushInput()
         return self.recurse(self.get_next_adc_voltage)
 
@@ -268,12 +268,12 @@ class BitBang(BusPirate):
         self.write((period >> 8) & 0xFF)
         self.write(period & 0xFF)
         self.timeout(self.minDelay * 10)
-        if self.response(1, True) != '\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not setup PWM mode")
 
     def disable_PWM(self):
         """ Clear/disable PWM """
         self.write(0x13)
         self.timeout(self.minDelay * 10)
-        if self.response(1, True) != '\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not disable PWM mode")

--- a/pyBusPirateLite/I2C.py
+++ b/pyBusPirateLite/I2C.py
@@ -235,7 +235,7 @@ class I2C(BusPirate):
             raise ValueError('Clock speed not supported')
         self.write(0x60 | clock)
 
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError('Could not set IC2 speed')
         self.i2c_speed = frequency
 
@@ -298,7 +298,7 @@ class I2C(BusPirate):
         self.write(numrx & 0xff)
         for data in txdata:
             self.write(data)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError('Error in transmission')
 
         return self.response(numrx, binary=True)
@@ -359,5 +359,5 @@ class I2C(BusPirate):
         if cs:
             data |= 0x01
         self.write(data)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError('Error configuring pins')

--- a/pyBusPirateLite/SPI.py
+++ b/pyBusPirateLite/SPI.py
@@ -130,7 +130,7 @@ class SPI(BusPirate):
         * AUX is always a normal pin output (0=GND, 1=3.3volts).
         """
         self.write(0x40 | (cfg & 0x0f))
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not set SPI pins")
         self._pins = cfg
 
@@ -169,7 +169,7 @@ class SPI(BusPirate):
         """
         self.write(0x80 | cfg)
         self.timeout(self.minDelay)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not set SPI configuration")
         self._config = cfg
 
@@ -210,9 +210,9 @@ class SPI(BusPirate):
         self.write(0x10 + length-1)
         for data in txdata:
             self.write(data)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not transfer SPI data")
-        rxdata = self.response(length, True)
+        rxdata = self.response(length, binary=True)
         return rxdata
 
     def write_then_read(self, numtx, numrx, txdata, cs=True):
@@ -276,7 +276,7 @@ class SPI(BusPirate):
         self.write(numrx & 0xff)
         for data in txdata:
             self.write(data)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError("Error transmitting data")
 
     @property
@@ -301,7 +301,7 @@ class SPI(BusPirate):
             self.write(0x02)
         else:
             self.write(0x03)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError("CS could not be set")
         self._cs = value
 
@@ -329,7 +329,7 @@ class SPI(BusPirate):
             raise ValueError('Clock speed not supported')
         self.write(0x60 | clock)
 
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError('Could not set SPI speed')
         self._speed = frequency
 
@@ -369,5 +369,5 @@ class SPI(BusPirate):
         else:
             cmd = 0x0d
         self.write(cmd)
-        if self.response(1, True) != b'\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ProtocolError('Could not set SPI sniff mode')

--- a/pyBusPirateLite/UART.py
+++ b/pyBusPirateLite/UART.py
@@ -107,7 +107,7 @@ class UART(BusPirate):
             self.write(0x03)
         else:
             self.write(0x02)
-        if self.response(1, True) != '\x01':
+        if self.response(1, binary=True) != b'\x01':
             raise ValueError("Could not set echo mode")
         self._echo = mode
 
@@ -142,14 +142,14 @@ class UART(BusPirate):
         """
         self.write(0x0f)
         self.timeout(0.1)
-        self.response(1, True)
+        self.response(1, binary=True)
 
     def set_cfg(self, cfg):
         self.write(0xC0 | cfg)
         self.timeout(0.1)
-        return self.response(1, True)
+        return self.response(1, binary=True)
 
     def read_cfg(self):
         self.write(0xd0)
         self.timeout(0.1)
-        return self.response(1, True)
+        return self.response(1, binary=True)

--- a/pyBusPirateLite/base.py
+++ b/pyBusPirateLite/base.py
@@ -140,7 +140,7 @@ class BusPirate:
         self.port.flushInput()
         for i in range(10):
             self.write(0x00)
-            r = self.response(1, True)
+            r = self.response(1, binary=True)
             if r:
                 break
             for m in range(2):
@@ -306,7 +306,7 @@ depend on the device you are interfacing with)"""
 def send_start_bit(self):
     self.write(0x02)
     self.response(1, True)
-    if self.response(1, True) == '\x01':
+    if self.response(1, binary=True) == b'\x01':
         self.recurse_end()
         return 1
     return self.recurse(self.send_start_bit)
@@ -314,7 +314,7 @@ def send_start_bit(self):
 
 def send_stop_bit(self):
     self.write(0x03)
-    if self.response(1, True) == 'x01':
+    if self.response(1, binary=True) == b'\x01':
         self.recurse_end()
         return 1
     return self.recurse(self.send_stop_bit)
@@ -325,11 +325,10 @@ def read_byte(self):
     byte manually.  NO ERROR CHECKING (obviously)"""
     if self.mode == 'raw':
         self.write(0x06)
-        return self.response(1, True)  # this was changed, before it didn't have the 'True' which means it
-        # would have never returned any real data!
+        return self.response(1, binary=True)
     else:
         self.write(0x04)
-        return self.response(1, True)
+        return self.response(1, binary=True)
 
 
 def bulk_trans(self, byte_count=1, byte_string=None):
@@ -347,8 +346,8 @@ def bulk_trans(self, byte_count=1, byte_string=None):
     self.write(0x10 | (byte_count - 1))
     for i in range(byte_count):
         self.write(byte_string[i])
-    data = self.response(byte_count + 1, True)
-    if ord(data[0]) == 1:  # bus pirate sent an acknolwedge properly
+    data = self.response(byte_count + 1, binary=True)
+    if data[0] == 1:  # bus pirate sent an acknolwedge properly
         self.recurse_end()
         return data[1:]
     self.recurse(self.bulk_trans, byte_count, byte_string)


### PR DESCRIPTION
Commit 4f8ae283e87b79706a726b84485cd75e650d4c8d changed the definition
of BBIO_Base.response() (BBIO_Base was later renamed to BusPirate) such
that the second argument went from a boolean that indicates that data
should be returned to a boolean that indicates if the data should be
decoded. There were a few cases where the old meaning was still assumed.

To prevent a similar bug, all instances of response() with a second
argument now use a keyword argument.