### PR TITLE
Fix tests and move to pytest

### DIFF
--- a/tests/test_bbio_base.py
+++ b/tests/test_bbio_base.py
@@ -1,91 +1,90 @@
 # -*- coding: utf-8 -*-
 from time import sleep
 
-from nose.tools import raises
+import pytest
 
-from pyBusPirateLite.BBIO_base import *
 from pyBusPirateLite.BitBang import BitBang
 
 
-@raises(TypeError)
 def test_outputs():
     """ Test if exception is raised when nothing is set yet """
-    bb = BitBang()
-    bb.outputs
-    bb.disconnect()
-    bb.hw_reset()
+    with pytest.raises(TypeError):
+        bb = BitBang()
+        bb.outputs
+        bb.disconnect()
+        bb.hw_reset()
 
 
 def test_pins_CS():
     """ Set and read back CS pin """
     bb = BitBang()
-    bb.outputs = PIN_CS
+    bb.outputs = bb.PIN_CS
     bb.pins = 0
     sleep(0.2)
     assert bb.outputs == 0
     assert bb.pins == 0
-    bb.pins = PIN_CS
+    bb.pins = bb.PIN_CS
     sleep(0.2)
-    assert bb.outputs == PIN_CS
-    assert bb.pins == PIN_CS
+    assert bb.outputs == bb.PIN_CS
+    assert bb.pins == bb.PIN_CS
     bb.hw_reset()
 
 
 def test_pins_MISO():
     """ Set and read back MISO pin """
     bb = BitBang()
-    bb.outputs = PIN_MISO
+    bb.outputs = bb.PIN_MISO
     bb.pins = 0
     sleep(0.2)
     assert bb.outputs == 0
     assert bb.pins == 0
-    bb.pins = PIN_MISO
+    bb.pins = bb.PIN_MISO
     sleep(0.2)
-    assert bb.outputs == PIN_MISO
-    assert bb.pins == PIN_MISO
+    assert bb.outputs == bb.PIN_MISO
+    assert bb.pins == bb.PIN_MISO
     bb.hw_reset()
 
 
 def test_pins_MOSI():
     """ Set and read back MOSI pin """
     bb = BitBang()
-    bb.outputs = PIN_MOSI
+    bb.outputs = bb.PIN_MOSI
     bb.pins = 0
     sleep(0.5)
     assert bb.outputs == 0
     assert bb.pins == 0
-    bb.pins = PIN_MOSI
+    bb.pins = bb.PIN_MOSI
     sleep(0.2)
-    assert bb.outputs == PIN_MOSI
-    assert bb.pins == PIN_MOSI
+    assert bb.outputs == bb.PIN_MOSI
+    assert bb.pins == bb.PIN_MOSI
     bb.hw_reset()
 
 
 def test_pins_CLK():
     """ Set and read back CLK pin """
     bb = BitBang()
-    bb.outputs = PIN_CLK
+    bb.outputs = bb.PIN_CLK
     bb.pins = 0
     sleep(0.2)
     assert bb.outputs == 0
     assert bb.pins == 0
-    bb.pins = PIN_CLK
+    bb.pins = bb.PIN_CLK
     sleep(0.2)
-    assert bb.outputs == PIN_CLK
-    assert bb.pins == PIN_CLK
+    assert bb.outputs == bb.PIN_CLK
+    assert bb.pins == bb.PIN_CLK
     bb.hw_reset()
 
 
 def test_pins_AUX():
     """ Set and read back AUX pin """
     bb = BitBang()
-    bb.outputs = PIN_AUX
+    bb.outputs = bb.PIN_AUX
     bb.pins = 0
     sleep(0.2)
     assert bb.outputs == 0
     assert bb.pins == 0
     sleep(0.2)
-    bb.pins = PIN_AUX
-    assert bb.outputs == PIN_AUX
-    assert bb.pins == PIN_AUX
+    bb.pins = bb.PIN_AUX
+    assert bb.outputs == bb.PIN_AUX
+    assert bb.pins == bb.PIN_AUX
     bb.hw_reset()

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyBusPirateLite.I2C import I2C
 
 
@@ -25,29 +27,36 @@ def test_connect_on_init():
     assert i2c.mode == 'i2c'
 
 
+@pytest.mark.xfail
 def test_echo():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_manual_speed_cfg():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_begin_input():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_end_input():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_enter_bridge_mode():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def def_set_cfg():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_read_cfg():
-    pass
+    raise NotImplementedError()

--- a/tests/test_spi.py
+++ b/tests/test_spi.py
@@ -1,4 +1,4 @@
-from pyBusPirateLite.SPI import CFG_IDLE, CFG_PUSH_PULL, SPI
+from pyBusPirateLite.SPI import SPI
 
 
 def test_init():

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pyBusPirateLite.UART import UART
 
 
@@ -33,29 +35,36 @@ def test_modestring():
     uart.hw_reset()
 
 
+@pytest.mark.xfail
 def test_echo():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_manual_speed_cfg():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_begin_input():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_end_input():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_enter_bridge_mode():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def def_set_cfg():
-    pass
+    raise NotImplementedError()
 
 
+@pytest.mark.xfail
 def test_read_cfg():
-    pass
+    raise NotImplementedError()


### PR DESCRIPTION
Tests wouldn't run due to some imports and you had tests that just had `pass`.  Fixed the imports and made the tests fail instead of falsely pass.  Pytest will report them as expected to fail due to `pytest.mark.xfail`.