### PR TITLE
Removal of master/slave jargon

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,8 +50,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'pyBusPirateLite'
@@ -230,7 +230,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'pyBusPirateLite.tex', 'pyBusPirateLite Documentation',
+  (main_doc, 'pyBusPirateLite.tex', 'pyBusPirateLite Documentation',
    'Juergen Hasch', 'manual'),
 ]
 
@@ -260,7 +260,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'pyBusPirateLite', 'pyBusPirateLite Documentation',
+    (main_doc, 'pyBusPirateLite', 'pyBusPirateLite Documentation',
      [author], 1)
 ]
 
@@ -274,7 +274,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'pyBusPirateLite', 'pyBusPirateLite Documentation',
+  (main_doc, 'pyBusPirateLite', 'pyBusPirateLite Documentation',
    author, 'pyBusPirateLite', 'Library to access BusPirate.',
    'Miscellaneous'),
 ]

--- a/pyBusPirateLite/I2C.py
+++ b/pyBusPirateLite/I2C.py
@@ -130,7 +130,7 @@ class I2C(BusPirate):
     def ack(self):
         """ Send ACK
 
-        Send an I2C ACK bit after reading a byte. Tells a slave device that you will read another byte.
+        Send an I2C ACK bit after reading a byte. Tells a subordinate device that you will read another byte.
 
         Raises
         ------
@@ -144,7 +144,7 @@ class I2C(BusPirate):
     def nack(self):
         """ Send NACK
 
-        Send an I2C NACK bit after reading a byte. Tells a slave device that you will stop reading,
+        Send an I2C NACK bit after reading a byte. Tells a subordinate device that you will stop reading,
         next bit should be an I2C stop bit.
 
         Raises
@@ -176,7 +176,7 @@ class I2C(BusPirate):
         once. Note that 0000 indicates 1 byte because there’s no reason to send 0.
 
         BP replies 0×01 to the bulk I2C command. After each data byte the Bus Pirate returns the ACK (0x00) or
-        NACK (0x01) bit from the slave device.
+        NACK (0x01) bit from the subordinate device.
 
         Parameters
         ----------
@@ -265,7 +265,7 @@ class I2C(BusPirate):
         Next, send the bytes to write. Bytes are buffered in the Bus Pirate, there is no acknowledgment that a byte is
         received.
         The Bus Pirate sends an I2C start bit, then all write bytes are sent at once. If an I2C write is not ACKed by a
-        slave device, then the operation will abort and the Bus Pirate will return 0x00 now
+        subordinate device, then the operation will abort and the Bus Pirate will return 0x00 now
         Read starts immediately after the write completes. Bytes are read from I2C into a buffer at max I2C speed
         (no waiting for UART). All read bytes are ACKed, except the last byte which is NACKed, this process is handled
         internally between the Bus Pirate and the I2C device

--- a/pyBusPirateLite/I2Chigh.py
+++ b/pyBusPirateLite/I2Chigh.py
@@ -66,7 +66,7 @@ class I2Chigh(I2C):
             raise IOError("I2C command on address 0x%02x not acknowledged!" % (i2caddr))
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit()
         stat = self.bulk_trans(2, [i2caddr << 1, cmd])
         self.send_stop_bit()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.