### PR TITLE
pyBusPirateLite/I2C.py: use raw string for sniffer

### DIFF
--- a/pyBusPirateLite/I2C.py
+++ b/pyBusPirateLite/I2C.py
@@ -157,7 +157,7 @@ class I2C(BusPirate):
             raise ProtocolError('Could not send NACK')
 
     def sniffer(self):
-        """ Sniff traffic on an I2C bus.
+        r""" Sniff traffic on an I2C bus.
 
         [/] - Start/stop bit
         \ - escape character precedes a data byte value


### PR DESCRIPTION
The I2C.sniffer function documentation raises a `SyntaxWarning` in more recent python versions (3.12 in this case), complaining about an `invalid escape sequence '\ '`.

This commit makes the string to be interpreted as raw instead.

Before:

```bash
$ python
Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyBusPirateLite import I2C
.../pyBusPirateLite/pyBusPirateLite/I2C.py:160: SyntaxWarning: invalid escape sequence '\ '
  """ Sniff traffic on an I2C bus.
```

After:

```bash
$ python
Python 3.12.2 (main, Feb  6 2024, 20:19:44) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyBusPirateLite import I2C
```

